### PR TITLE
adding configuration text color in dialog permission

### DIFF
--- a/chat/src/main/java/com/qiscus/sdk/data/model/QiscusChatConfig.java
+++ b/chat/src/main/java/com/qiscus/sdk/data/model/QiscusChatConfig.java
@@ -133,6 +133,9 @@ public class QiscusChatConfig {
     private int cardButtonTextColor = R.color.qiscus_primary;
     private int cardButtonBackground = R.color.qiscus_white;
 
+    private int dialogPermissionPositiveButtonTextColor = R.color.qiscus_primary;
+    private int dialogPermissionNegativeButtonTextColor = R.color.qiscus_secondary_text;
+
     private int playAudioIcon = R.drawable.ic_qiscus_play_audio;
     private int pauseAudioIcon = R.drawable.ic_qiscus_pause_audio;
     private int showEmojiIcon = R.drawable.ic_qiscus_emot;
@@ -687,6 +690,18 @@ public class QiscusChatConfig {
         return this;
     }
 
+    public QiscusChatConfig setDialogPermissionPositiveButtonTextColor
+            (@ColorRes int dialogPermissionPositiveButtonTextColor) {
+        this.dialogPermissionPositiveButtonTextColor = dialogPermissionPositiveButtonTextColor;
+        return this;
+    }
+
+    public QiscusChatConfig setDialogPermissionNegativeButtonTextColor
+            (@ColorRes int dialogPermissionNegativeButtonTextColor) {
+        this.dialogPermissionNegativeButtonTextColor = dialogPermissionNegativeButtonTextColor;
+        return this;
+    }
+
     @ColorRes
     public int getStatusBarColor() {
         return statusBarColor;
@@ -1129,5 +1144,15 @@ public class QiscusChatConfig {
 
     public boolean isEnableCaption() {
         return enableCaption;
+    }
+
+    @ColorRes
+    public int getDialogPermissionPositiveButtonTextColor() {
+        return dialogPermissionPositiveButtonTextColor;
+    }
+
+    @ColorRes
+    public int getDialogPermissionNegativeButtonTextColor() {
+        return dialogPermissionNegativeButtonTextColor;
     }
 }

--- a/chat/src/main/java/com/qiscus/sdk/util/QiscusPermissionsUtil.java
+++ b/chat/src/main/java/com/qiscus/sdk/util/QiscusPermissionsUtil.java
@@ -18,6 +18,7 @@ package com.qiscus.sdk.util;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -29,6 +30,8 @@ import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
+
+import com.qiscus.sdk.Qiscus;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -106,6 +109,14 @@ public final class QiscusPermissionsUtil {
                         callbacks.onPermissionsDenied(requestCode, Arrays.asList(perms));
                     }).create();
             dialog.show();
+
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor
+                    (ContextCompat.getColor(Qiscus.getApps(),
+                            Qiscus.getChatConfig().getDialogPermissionPositiveButtonTextColor()));
+            dialog.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor
+                    (ContextCompat.getColor(Qiscus.getApps(),
+                            Qiscus.getChatConfig().getDialogPermissionNegativeButtonTextColor()));
+
         } else {
             executePermissionsRequest(object, perms, requestCode);
         }
@@ -169,7 +180,15 @@ public final class QiscusPermissionsUtil {
                         })
                         .setNegativeButton(negativeButton, null)
                         .create();
+
                 dialog.show();
+
+                dialog.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor
+                        (ContextCompat.getColor(Qiscus.getApps(),
+                        Qiscus.getChatConfig().getDialogPermissionPositiveButtonTextColor()));
+                dialog.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor
+                        (ContextCompat.getColor(Qiscus.getApps(),
+                        Qiscus.getChatConfig().getDialogPermissionNegativeButtonTextColor()));
 
                 return true;
             }


### PR DESCRIPTION
User able to config dialog permission text color :
1. For positive button :
```
Qiscus.getChatConfig()
                .setDialogPermissionPositiveButtonTextColor(R.color.primary);
```
2. For negative button :
```
Qiscus.getChatConfig()
                .setDialogPermissionNegativeButtonTextColor(R,color.acent);
```