### PR TITLE
room sender color interceptor

### DIFF
--- a/chat/src/main/java/com/qiscus/sdk/data/model/QiscusChatConfig.java
+++ b/chat/src/main/java/com/qiscus/sdk/data/model/QiscusChatConfig.java
@@ -162,6 +162,7 @@ public class QiscusChatConfig {
     private QiscusRoomSenderNameInterceptor qiscusRoomSenderNameInterceptor = QiscusComment::getSender;
     private QiscusCommentSendingInterceptor qiscusCommentSendingInterceptor = qiscusComment -> qiscusComment;
     private QiscusRoomSenderNameColorInterceptor qiscusRoomSenderNameColorInterceptor = qiscusComment -> R.color.qiscus_secondary_text;
+    private QiscusRoomReplybarColorInterceptor qiscusRoomReplybarColorInterceptor = qiscusComment -> R.color.qiscus_primary;
 
     private NotificationClickListener notificationClickListener =
             (context, qiscusComment) -> QiscusApi.getInstance()
@@ -715,9 +716,15 @@ public class QiscusChatConfig {
         return this;
     }
 
-    public QiscusChatConfig setQiscusRoomSenderNameColorInterceptor(QiscusRoomSenderNameColorInterceptor
+    public QiscusChatConfig setRoomSenderNameColorInterceptor(QiscusRoomSenderNameColorInterceptor
                                                                 qiscusRoomSenderNameColorInterceptor) {
         this.qiscusRoomSenderNameColorInterceptor = qiscusRoomSenderNameColorInterceptor;
+        return this;
+    }
+
+    public QiscusChatConfig setRoomReplybarColorInterceptor(QiscusRoomReplybarColorInterceptor
+                                                              qiscusRoomReplybarColorInterceptor) {
+        this.qiscusRoomReplybarColorInterceptor = qiscusRoomReplybarColorInterceptor;
         return this;
     }
 
@@ -1215,6 +1222,10 @@ public class QiscusChatConfig {
 
     public QiscusRoomSenderNameColorInterceptor getRoomSenderNameColorInterceptor() {
         return qiscusRoomSenderNameColorInterceptor;
+    }
+
+    public QiscusRoomReplybarColorInterceptor getRoomReplybarColorInterceptor() {
+        return qiscusRoomReplybarColorInterceptor;
     }
 
     public QiscusCommentSendingInterceptor getCommentSendingInterceptor() {

--- a/chat/src/main/java/com/qiscus/sdk/data/model/QiscusChatConfig.java
+++ b/chat/src/main/java/com/qiscus/sdk/data/model/QiscusChatConfig.java
@@ -161,6 +161,7 @@ public class QiscusChatConfig {
     private NotificationTitleHandler notificationTitleHandler = QiscusComment::getRoomName;
     private QiscusRoomSenderNameInterceptor qiscusRoomSenderNameInterceptor = QiscusComment::getSender;
     private QiscusCommentSendingInterceptor qiscusCommentSendingInterceptor = qiscusComment -> qiscusComment;
+    private QiscusRoomSenderNameColorInterceptor qiscusRoomSenderNameColorInterceptor = qiscusComment -> R.color.qiscus_secondary_text;
 
     private NotificationClickListener notificationClickListener =
             (context, qiscusComment) -> QiscusApi.getInstance()
@@ -714,6 +715,12 @@ public class QiscusChatConfig {
         return this;
     }
 
+    public QiscusChatConfig setQiscusRoomSenderNameColorInterceptor(QiscusRoomSenderNameColorInterceptor
+                                                                qiscusRoomSenderNameColorInterceptor) {
+        this.qiscusRoomSenderNameColorInterceptor = qiscusRoomSenderNameColorInterceptor;
+        return this;
+    }
+
     public QiscusChatConfig setCommentSendingInterceptor(QiscusCommentSendingInterceptor
                                                                  qiscusCommentSendingInterceptor) {
         this.qiscusCommentSendingInterceptor = qiscusCommentSendingInterceptor;
@@ -1204,6 +1211,10 @@ public class QiscusChatConfig {
 
     public QiscusRoomSenderNameInterceptor getRoomSenderNameInterceptor() {
         return qiscusRoomSenderNameInterceptor;
+    }
+
+    public QiscusRoomSenderNameColorInterceptor getRoomSenderNameColorInterceptor() {
+        return qiscusRoomSenderNameColorInterceptor;
     }
 
     public QiscusCommentSendingInterceptor getCommentSendingInterceptor() {

--- a/chat/src/main/java/com/qiscus/sdk/data/model/QiscusRoomReplybarColorInterceptor.java
+++ b/chat/src/main/java/com/qiscus/sdk/data/model/QiscusRoomReplybarColorInterceptor.java
@@ -1,0 +1,13 @@
+package com.qiscus.sdk.data.model;
+
+import android.support.annotation.ColorRes;
+
+/**
+ * @author yuana <andhikayuana@gmail.com>
+ * @since 1/10/18
+ */
+
+public interface QiscusRoomReplybarColorInterceptor {
+    @ColorRes
+    int getColor(QiscusComment qiscusComment);
+}

--- a/chat/src/main/java/com/qiscus/sdk/data/model/QiscusRoomSenderNameColorInterceptor.java
+++ b/chat/src/main/java/com/qiscus/sdk/data/model/QiscusRoomSenderNameColorInterceptor.java
@@ -1,0 +1,13 @@
+package com.qiscus.sdk.data.model;
+
+import android.support.annotation.ColorRes;
+
+/**
+ * @author yuana <andhikayuana@gmail.com>
+ * @since 1/10/18
+ */
+
+public interface QiscusRoomSenderNameColorInterceptor {
+    @ColorRes
+    int getColor(QiscusComment qiscusComment);
+}

--- a/chat/src/main/java/com/qiscus/sdk/data/remote/QiscusApi.java
+++ b/chat/src/main/java/com/qiscus/sdk/data/remote/QiscusApi.java
@@ -61,6 +61,7 @@ import okio.Source;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.http.DELETE;
 import retrofit2.http.Field;
 import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
@@ -340,6 +341,20 @@ public enum QiscusApi {
                 .toList();
     }
 
+    public Observable<Void> clearChatRoomMessages(List<String> roomChannelIds) {
+        return api.clearChatRoomMessages(Qiscus.getToken(), roomChannelIds)
+                .map(JsonElement::getAsJsonObject)
+                .map(jsonResponse -> jsonResponse.get("results").getAsJsonObject())
+                .map(jsonResults -> jsonResults.get("rooms").getAsJsonArray())
+                .flatMap(Observable::from)
+                .map(JsonElement::getAsJsonObject)
+                .map(jsonObject -> jsonObject.get("unique_id").getAsString())
+                .map(s -> Qiscus.getDataStore().getChatRoomWithUniqueId(s))
+                .doOnNext(qiscusChatRoom -> Qiscus.getDataStore().deleteCommentsByRoomId(qiscusChatRoom.getId()))
+                .toList()
+                .map(qiscusChatRooms -> null);
+    }
+
     private interface Api {
 
         @POST("/api/v2/auth/nonce")
@@ -448,6 +463,10 @@ public enum QiscusApi {
                                              @Field("room_id[]") List<Integer> roomIds,
                                              @Field("room_unique_id[]") List<String> roomUniqueIds,
                                              @Field("show_participants") boolean showParticipants);
+
+        @DELETE("/api/v2/sdk/clear_room_messages")
+        Observable<JsonElement> clearChatRoomMessages(@Query("token") String token,
+                                                      @Query("room_channel_ids[]") List<String> roomChannelIds);
     }
 
     private static class CountingFileRequestBody extends RequestBody {

--- a/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseMessageViewHolder.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseMessageViewHolder.java
@@ -191,6 +191,11 @@ public abstract class QiscusBaseMessageViewHolder<E extends QiscusComment> exten
         if (senderNameView != null && !messageFromMe && groupChat) {
             if (needToShowFirstMessageBubbleIndicator) {
                 senderNameView.setVisibility(View.VISIBLE);
+                senderNameView.setTextColor(ContextCompat
+                        .getColor(Qiscus.getApps(), Qiscus
+                        .getChatConfig()
+                        .getRoomSenderNameColorInterceptor()
+                        .getColor(qiscusComment)));
                 senderNameView.setText(String.format("~ %s", Qiscus
                         .getChatConfig()
                         .getRoomSenderNameInterceptor()

--- a/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseReplyMessageViewHolder.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseReplyMessageViewHolder.java
@@ -137,6 +137,10 @@ public abstract class QiscusBaseReplyMessageViewHolder extends QiscusBaseTextMes
                         .getChatConfig()
                         .getRoomSenderNameColorInterceptor()
                         .getColor(qiscusComment)));
+        if (barView != null) {
+            barView.setBackgroundColor(ContextCompat.getColor(Qiscus.getApps(),
+                    Qiscus.getChatConfig().getRoomReplybarColorInterceptor().getColor(qiscusComment)));
+        }
         switch (originComment.getType()) {
             case IMAGE:
             case VIDEO:

--- a/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseReplyMessageViewHolder.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseReplyMessageViewHolder.java
@@ -132,6 +132,11 @@ public abstract class QiscusBaseReplyMessageViewHolder extends QiscusBaseTextMes
         originSenderTextView.setText(originComment.getSenderEmail().equals(qiscusAccount.getEmail()) ?
                 QiscusTextUtil.getString(R.string.qiscus_you) : Qiscus.getChatConfig().getRoomSenderNameInterceptor()
                 .getSenderName(originComment));
+        originSenderTextView.setTextColor(ContextCompat
+                .getColor(Qiscus.getApps(), Qiscus
+                        .getChatConfig()
+                        .getRoomSenderNameColorInterceptor()
+                        .getColor(qiscusComment)));
         switch (originComment.getType()) {
             case IMAGE:
             case VIDEO:

--- a/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseReplyMessageViewHolder.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/adapter/viewholder/QiscusBaseReplyMessageViewHolder.java
@@ -127,7 +127,6 @@ public abstract class QiscusBaseReplyMessageViewHolder extends QiscusBaseTextMes
                 replyItemClickListener.onReplyItemClick(qiscusComment);
             }
         });
-
         QiscusComment originComment = qiscusComment.getReplyTo();
         originSenderTextView.setText(originComment.getSenderEmail().equals(qiscusAccount.getEmail()) ?
                 QiscusTextUtil.getString(R.string.qiscus_you) : Qiscus.getChatConfig().getRoomSenderNameInterceptor()
@@ -136,10 +135,10 @@ public abstract class QiscusBaseReplyMessageViewHolder extends QiscusBaseTextMes
                 .getColor(Qiscus.getApps(), Qiscus
                         .getChatConfig()
                         .getRoomSenderNameColorInterceptor()
-                        .getColor(qiscusComment)));
+                        .getColor(originComment)));
         if (barView != null) {
             barView.setBackgroundColor(ContextCompat.getColor(Qiscus.getApps(),
-                    Qiscus.getChatConfig().getRoomReplybarColorInterceptor().getColor(qiscusComment)));
+                    Qiscus.getChatConfig().getRoomReplybarColorInterceptor().getColor(originComment)));
         }
         switch (originComment.getType()) {
             case IMAGE:

--- a/chat/src/main/java/com/qiscus/sdk/ui/view/QiscusReplyPreviewView.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/view/QiscusReplyPreviewView.java
@@ -110,6 +110,7 @@ public class QiscusReplyPreviewView extends LinearLayout {
         } else {
             sender.setText(Qiscus.getChatConfig().getRoomSenderNameInterceptor().getSenderName(originComment));
             sender.setTextColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig().getRoomSenderNameColorInterceptor().getColor(originComment)));
+            setBarColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig().getRoomReplybarColorInterceptor().getColor(originComment)));
             switch (originComment.getType()) {
                 case IMAGE:
                 case VIDEO:

--- a/chat/src/main/java/com/qiscus/sdk/ui/view/QiscusReplyPreviewView.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/view/QiscusReplyPreviewView.java
@@ -108,9 +108,12 @@ public class QiscusReplyPreviewView extends LinearLayout {
             content.setText(null);
             setVisibility(GONE);
         } else {
-            sender.setText(Qiscus.getChatConfig().getRoomSenderNameInterceptor().getSenderName(originComment));
-            sender.setTextColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig().getRoomSenderNameColorInterceptor().getColor(originComment)));
-            setBarColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig().getRoomReplybarColorInterceptor().getColor(originComment)));
+            sender.setText(Qiscus.getChatConfig().getRoomSenderNameInterceptor()
+                    .getSenderName(originComment));
+            sender.setTextColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig()
+                    .getRoomSenderNameColorInterceptor().getColor(originComment)));
+            setBarColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig()
+                    .getRoomReplybarColorInterceptor().getColor(originComment)));
             switch (originComment.getType()) {
                 case IMAGE:
                 case VIDEO:

--- a/chat/src/main/java/com/qiscus/sdk/ui/view/QiscusReplyPreviewView.java
+++ b/chat/src/main/java/com/qiscus/sdk/ui/view/QiscusReplyPreviewView.java
@@ -19,6 +19,7 @@ package com.qiscus.sdk.ui.view;
 import android.content.Context;
 import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -108,6 +109,7 @@ public class QiscusReplyPreviewView extends LinearLayout {
             setVisibility(GONE);
         } else {
             sender.setText(Qiscus.getChatConfig().getRoomSenderNameInterceptor().getSenderName(originComment));
+            sender.setTextColor(ContextCompat.getColor(Qiscus.getApps(), Qiscus.getChatConfig().getRoomSenderNameColorInterceptor().getColor(originComment)));
             switch (originComment.getType()) {
                 case IMAGE:
                 case VIDEO:


### PR DESCRIPTION
to intercept sender color name 
example

```java
Qiscus.getChatConfig().setRoomSenderNameColorInterceptor(qiscusComment -> R.color.accent);

//or you can set the logic inside

Qiscus.getChatConfig().setRoomSenderNameColorInterceptor(qiscusComment -> {
            if (anu) {
                return R.color.colorAnu;
            } else if (anu2) {
                return R.color.colorAnu2;
            } else {
                return R.color.colorAnu3;
            }
        });

//replybar color
Qiscus.getChatConfig()
                .setRoomReplybarColorInterceptor(qiscusComment -> R.color.qiscus_contact_background);

//clear chats
ArrayList<String> strings = new ArrayList<>();
        strings.add("uniqueid");

        QiscusApi.getInstance()
                .clearChatRoomMessages(strings)
                .subscribeOn(Schedulers.io())
                .observeOn(AndroidSchedulers.mainThread())
                .subscribe(aVoid -> Toast.makeText(MainActivity.this, "Berhasil", Toast.LENGTH_SHORT).show(), Throwable::printStackTrace);
```