### PR TITLE
implement WAL

### DIFF
--- a/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/local/QiscusDataBaseHelper.java
+++ b/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/local/QiscusDataBaseHelper.java
@@ -1173,7 +1173,7 @@ public class QiscusDataBaseHelper implements QiscusDataStore {
         } catch (Exception e) {
             QiscusErrorLogger.print(e);
         } finally {
-            sqLiteWriteDatabase.endTransaction();
+            sqLiteReadDatabase.endTransaction();
         }
     }
 

--- a/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/local/QiscusDataBaseHelper.java
+++ b/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/local/QiscusDataBaseHelper.java
@@ -456,7 +456,8 @@ public class QiscusDataBaseHelper implements QiscusDataStore {
 
         sqLiteWriteDatabase.beginTransactionNonExclusive();
         try {
-            sqLiteWriteDatabase.update(QiscusDb.MemberTable.TABLE_NAME, QiscusDb.MemberTable.toContentValues(qiscusRoomMember), where, null);
+            sqLiteWriteDatabase.update(QiscusDb.MemberTable.TABLE_NAME,
+                    QiscusDb.MemberTable.toContentValues(qiscusRoomMember), where, null);
             sqLiteWriteDatabase.setTransactionSuccessful();
         } catch (Exception e) {
             QiscusErrorLogger.print(e);

--- a/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/local/QiscusDbOpenHelper.java
+++ b/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/local/QiscusDbOpenHelper.java
@@ -21,6 +21,7 @@ import android.content.res.AssetManager;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.qiscus.sdk.chat.core.util.QiscusLogger;
 
@@ -51,6 +52,13 @@ class QiscusDbOpenHelper extends SQLiteOpenHelper {
         } finally {
             db.endTransaction();
         }
+    }
+
+    @Override
+    public void onOpen(SQLiteDatabase db) {
+        super.onOpen(db);
+        QiscusLogger.print("Opening database.. ");
+        db.enableWriteAheadLogging();
     }
 
     @Override

--- a/chat-core/src/main/java/com/qiscus/sdk/chat/core/util/QiscusLogger.java
+++ b/chat-core/src/main/java/com/qiscus/sdk/chat/core/util/QiscusLogger.java
@@ -22,7 +22,7 @@ public final class QiscusLogger {
 
     public static void print(String tag, String message) {
         if (QiscusCore.getChatConfig().isEnableLog()) {
-            Log.i(tag, message);
+            Log.d(tag, message);
         }
     }
 }


### PR DESCRIPTION
This `PR` to improve how to handle the deadlcok issue
http://tleyden.github.io/blog/2013/11/14/investigating-an-android-sqlite-threading-deadlock/

However, the implementation of Qiscus Chat SDK might be considered as well. 

Reference:
Based on this article enable WAL allow to read the database during a transaction process
https://developer.android.com/reference/android/database/sqlite/SQLiteDatabase#enableWriteAheadLogging()

" when write-ahead logging is enabled (by calling this method), write operations occur in a separate log file which allows reads to proceed concurrently. While a write is in progress, readers on other threads will perceive the state of the database as it was before the write began. When the write completes, readers on other threads will then perceive the new state of the database."

