### PR TITLE
Adding get users API

### DIFF
--- a/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/remote/QiscusApi.java
+++ b/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/remote/QiscusApi.java
@@ -555,6 +555,22 @@ public enum QiscusApi {
                 .map(QiscusApiParser::parseQiscusCommentInfo);
     }
 
+    public Observable<List<QiscusAccount>> getUsers(String orderQuery, String query) {
+        return getUsers(0, 100, orderQuery, query);
+    }
+
+    public Observable<List<QiscusAccount>> getUsers(long page, long limit, String orderQuery,
+                                                       String query) {
+        return api.getUserList(QiscusCore.getToken(), page, limit, orderQuery, query)
+                .map(JsonElement::getAsJsonObject)
+                .map(jsonResponse -> jsonResponse.getAsJsonObject("results"))
+                .map(jsonResults -> jsonResults.getAsJsonArray("users"))
+                .flatMap(Observable::from)
+                .map(JsonElement::getAsJsonObject)
+                .map(jsonAccount -> QiscusApiParser.parseQiscusAccount(jsonAccount, false))
+                .toList();
+    }
+
     private interface Api {
 
         @POST("api/v2/auth/nonce")
@@ -776,6 +792,15 @@ public enum QiscusApi {
         Observable<JsonElement> getCommentReceipt(
                 @Query("token") String token,
                 @Query("comment_id") long commentId
+        );
+
+        @GET("/api/v2/mobile/get_user_list")
+        Observable<JsonElement> getUserList(
+                @Query("token") String token,
+                @Query("page") long page,
+                @Query("limit") long limit,
+                @Query("order_query") String orderQuery,
+                @Query("query") String query
         );
     }
 


### PR DESCRIPTION
Added  get users API 

How to call this function : 

1. Params : `order query` and the `query` itself,   query means what username you are looking for
```
QiscusApi.getInstance().getUsers("created at desc", "marco")
                .subscribeOn(Schedulers.io())
                .observeOn(AndroidSchedulers.mainThread())
                .subscribe(new Action1<List<QiscusAccount>>() {
                    @Override
                    public void call(List<QiscusAccount> qiscusAccounts) {
                        Log.d("MainActivity", "call: " + qiscusAccounts.get(0).getUsername());
                    }
                }, new Action1<Throwable>() {
                    @Override
                    public void call(Throwable throwable) {
                        throwable.printStackTrace();
                    }
                })
```

2. 
Params : `page`, `limit`= max limit per page is 100, the default is 20, `order query` and the `query` itself,   query means what username you are looking for
```
QiscusApi.getInstance().getUsers(1, 20,"created at desc", "marco")
                .subscribeOn(Schedulers.io())
                .observeOn(AndroidSchedulers.mainThread())
                .subscribe(new Action1<List<QiscusAccount>>() {
                    @Override
                    public void call(List<QiscusAccount> qiscusAccounts) {
                        Log.d("MainActivity", "call: " + qiscusAccounts.get(0).getUsername());
                    }
                }, new Action1<Throwable>() {
                    @Override
                    public void call(Throwable throwable) {
                        throwable.printStackTrace();
                    }
                })
```