### PR TITLE
fix user presence timestamp

### DIFF
--- a/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/remote/QiscusApiParser.java
+++ b/chat-core/src/main/java/com/qiscus/sdk/chat/core/data/remote/QiscusApiParser.java
@@ -622,7 +622,7 @@ final class QiscusApiParser {
         }
 
         if (jsonUserStatus.has("timestamp")) {
-            long timestamp = jsonUserStatus.get("timestamp").getAsLong() / 1000000L;
+            long timestamp = jsonUserStatus.get("timestamp").getAsLong() * 1000;
             userPresence.setTimestamp(new Date(timestamp));
         }
 


### PR DESCRIPTION
Hello pak @adicatur ,
there was a bug when parsing timestamp in API `/users/status`. backend used `unix timestamp`, but the android sdk assume using `unix nano timestamp`.
So we just times with `1000` because Date class need `millisec`
